### PR TITLE
Getting whole hierarchy

### DIFF
--- a/.changeset/wise-cows-flash.md
+++ b/.changeset/wise-cows-flash.md
@@ -1,0 +1,10 @@
+---
+"@zazuko/cube-hierarchy-query": minor
+---
+
+Getting entire hierarchy. See example in `examples/hierarchy.ts`. Run it like
+
+```
+yarn run example examples/hierarchy.ts \
+  --cube https://environment.ld.admin.ch/foen/fab_Offentliche_Ausgaben_test3/7
+```

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ PREFIX sh: <http://www.w3.org/ns/shacl#>
 The simplest usage is to retrieve entire hierarchy. It generates a `DESCRIBE` SPARQL query which will retrieve triples of
 the root resources and all resources on all hierarchy levels.
 
+* `sh:targetClass`, if present is added as a restriction on each applicable level
+
 ```typescript
 import { getHierarchy } from '@zazuko/cube-hierarchy-query'
 import $rdf from 'rdf-ext'

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Use it to work with hierarchies defined using the [RDF Cube Schema](https://zazu
 The examples below assume `dataset` is an RDF/JS graph of Swiss cantons:
 
 ```turtle
+PREFIX schema: <http://schema.org/>
 PREFIX meta: <https://cube.link/meta/>
 PREFIX sh: <http://www.w3.org/ns/shacl#>
 
@@ -28,6 +29,33 @@ PREFIX sh: <http://www.w3.org/ns/shacl#>
 <hierarchy/Switzerland/districts>
   schema:name "Districts" ;
   sh:path [ sh:inversePath schema:containedInPlace ] .
+```
+
+### Get entire hierarchy
+
+The simplest usage is to retrieve entire hierarchy. It generates a `DESCRIBE` SPARQL query which will retrieve triples of
+the root resources and all resources on all hierarchy levels.
+
+```typescript
+import { getHierarchy } from '@zazuko/cube-hierarchy-query'
+import $rdf from 'rdf-ext'
+import StreamClient from 'sparql-http-builder'
+
+let dataset: DatasetCore
+const client = new StreamClient()
+
+const myHierarchy = clownface({ dataset }).namedNode('my-hierarchy')
+const results = await getHierarchy(myHierarchy).execute(client, $rdf)
+
+results.forEach(print(0))
+
+function print(indent: number) {
+  return (hierarchyLevel: HierarchyNode) => {
+    const { value } = hierarchyLevel.resource
+    console.log(value.padStart(value.length + indent))
+    hierarchyLevel.nextInHierarchy.forEach(print(indent + 2))
+  }
+}
 ```
 
 ### Find resources
@@ -90,7 +118,6 @@ const client = new StreamClient()
 
 const stream = await types(cantonLevel).execute(client.query)
 ```
-
 
 ## Examples
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - examples

--- a/examples/hierarchy.ts
+++ b/examples/hierarchy.ts
@@ -1,0 +1,52 @@
+import StreamClient from 'sparql-http-client'
+import argparse from 'argparse'
+import $rdf from 'rdf-ext'
+import { Source } from 'rdf-cube-view-query'
+import { sh } from '@tpluscode/rdf-ns-builders'
+import { meta } from '@zazuko/vocabulary-extras/builders'
+import { isGraphPointer } from 'is-graph-pointer'
+import { getHierarchy, HierarchyNode } from '..'
+
+const main = async () => {
+  const parser = new argparse.ArgumentParser()
+  parser.add_argument('--cube', { required: true })
+  parser.add_argument('--dimensionIri', { required: false })
+  parser.add_argument('--endpoint', { required: false, default: 'https://int.lindas.admin.ch/query' })
+
+  const args = parser.parse_args()
+  const endpoint = {
+    endpointUrl: args.endpoint,
+  }
+  const client = new StreamClient(endpoint)
+  const cube = await new Source(endpoint).cube(args.cube)
+
+  await cube.fetchShape()
+  const hierarchy = cube.ptr
+    .any()
+    .has(sh.path, $rdf.namedNode(args.dimensionIri))
+    .has(meta.inHierarchy)
+    .out(meta.inHierarchy)
+    .toArray()
+    .shift()
+
+  if (!isGraphPointer(hierarchy)) {
+    throw new Error(`Hierarchy not found ${args.dimensionIri}`)
+  }
+
+  const results = await getHierarchy(hierarchy).execute(client, $rdf)
+
+  results.forEach(print(0))
+}
+
+function print(indent: number) {
+  return (hierarchyLevel: HierarchyNode) => {
+    const { value } = hierarchyLevel.resource
+    console.log(value.padStart(value.length + indent))
+    hierarchyLevel.nextInHierarchy.forEach(print(indent + 2))
+  }
+}
+
+main().catch(e => {
+  console.error(e)
+  process.exit(1)
+})

--- a/index.ts
+++ b/index.ts
@@ -10,27 +10,22 @@ import { isGraphPointer } from 'is-graph-pointer'
 import { topDown } from './lib/patterns.js'
 
 export class HierarchyNode {
-  private readonly path: GraphPointer
-  private readonly nextLevel: GraphPointer
-
-  constructor(public readonly resource: GraphPointer, hierarchyLevel: GraphPointer) {
-    const path = hierarchyLevel.out(sh.path)
-    const nextLevel = hierarchyLevel.out(meta.nextInHierarchy)
-
-    if (!isGraphPointer(path)) {
-      throw new Error('sh:path must be single node')
-    }
-    if (!isGraphPointer(nextLevel)) {
-      throw new Error('meta:nextInHierarchy must be single node')
-    }
-
-    this.path = path
-    this.nextLevel = nextLevel
+  constructor(public readonly resource: GraphPointer, private hierarchyLevel: GraphPointer) {
   }
 
   get nextInHierarchy(): Array<HierarchyNode> {
-    return findNodes(this.resource, this.path)
-      .map(child => new HierarchyNode(child, this.nextLevel))
+    const nextLevel = this.hierarchyLevel.out(meta.nextInHierarchy)
+    if (!isGraphPointer(nextLevel)) {
+      return []
+    }
+
+    const path = nextLevel.out(sh.path)
+    if (!isGraphPointer(path)) {
+      throw new Error('sh:path must be single node')
+    }
+
+    return findNodes(this.resource, path)
+      .map(child => new HierarchyNode(child, nextLevel))
   }
 }
 

--- a/index.ts
+++ b/index.ts
@@ -1,0 +1,61 @@
+import { DatasetCoreFactory } from 'rdf-js'
+import clownface, { GraphPointer } from 'clownface'
+import { Construct, DESCRIBE } from '@tpluscode/sparql-builder'
+import type StreamClient from 'sparql-http-client'
+import fromStream from 'rdf-dataset-ext/fromStream.js'
+import { meta } from '@zazuko/vocabulary-extras/builders'
+import { findNodes } from 'clownface-shacl-path'
+import { sh } from '@tpluscode/rdf-ns-builders'
+import { isGraphPointer } from 'is-graph-pointer'
+import { topDown } from './lib/patterns.js'
+
+export class HierarchyNode {
+  private readonly path: GraphPointer
+  private readonly nextLevel: GraphPointer
+
+  constructor(public readonly resource: GraphPointer, hierarchyLevel: GraphPointer) {
+    const path = hierarchyLevel.out(sh.path)
+    const nextLevel = hierarchyLevel.out(meta.nextInHierarchy)
+
+    if (!isGraphPointer(path)) {
+      throw new Error('sh:path must be single node')
+    }
+    if (!isGraphPointer(nextLevel)) {
+      throw new Error('meta:nextInHierarchy must be single node')
+    }
+
+    this.path = path
+    this.nextLevel = nextLevel
+  }
+
+  get nextInHierarchy(): Array<HierarchyNode> {
+    return findNodes(this.resource, this.path)
+      .map(child => new HierarchyNode(child, this.nextLevel))
+  }
+}
+
+export interface Hierarchy {
+  query: Construct
+  execute(
+    client: StreamClient,
+    rdf: DatasetCoreFactory,
+  ): Promise<Array<HierarchyNode>>
+}
+
+export function getHierarchy(hierarchy: GraphPointer): Hierarchy {
+  const query = DESCRIBE`*`
+    .WHERE`
+      ${topDown(hierarchy)}
+    `
+
+  return {
+    query,
+    async execute(client, $rdf) {
+      const stream = await query.execute(client.query)
+      const dataset = await fromStream($rdf.dataset(), stream)
+      const roots = clownface({ dataset }).node(hierarchy.out(meta.hierarchyRoot))
+
+      return roots.map(root => new HierarchyNode(root, hierarchy))
+    },
+  }
+}

--- a/introspect.ts
+++ b/introspect.ts
@@ -2,7 +2,7 @@ import { Construct, CONSTRUCT, SELECT } from '@tpluscode/sparql-builder'
 import { rdfs } from '@tpluscode/rdf-ns-builders'
 import { GraphPointer } from 'clownface'
 import { meta } from '@zazuko/vocabulary-extras/builders'
-import { getHierarchyPatterns } from './lib/patterns.js'
+import { bottomUp } from './lib/patterns.js'
 import { anyPath } from './lib/firstLevel.js'
 
 /**
@@ -12,7 +12,7 @@ import { anyPath } from './lib/firstLevel.js'
  * @param {GraphPointer} hierarchyLevel it must be a pointer to the full hierarchy dataset
  */
 export function properties(hierarchyLevel: GraphPointer): Construct | null {
-  const patterns = getHierarchyPatterns(hierarchyLevel, {
+  const patterns = bottomUp(hierarchyLevel, {
     firstLevel: anyPath,
   })
   if (!patterns) {
@@ -40,7 +40,7 @@ export function properties(hierarchyLevel: GraphPointer): Construct | null {
  * @param {GraphPointer} hierarchyLevel it must be a pointer to the full hierarchy dataset
  */
 export function types(hierarchyLevel: GraphPointer): Construct | null {
-  const patterns = getHierarchyPatterns(hierarchyLevel, {
+  const patterns = bottomUp(hierarchyLevel, {
     restrictTypes: false,
     firstLevel: anyPath,
   })

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0-pre.2",
   "description": "Facilitates querying RDF cube hierarchies",
   "type": "module",
+  "main": "index.js",
   "scripts": {
     "lint": "eslint . --ext .ts --quiet --ignore-path .gitignore",
     "test": "c8 --all --reporter=lcov mocha",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@zazuko/vocabulary-extras": "^1.0.1",
     "clownface": "^1.5.1",
     "clownface-shacl-path": "^1.3.2",
+    "is-graph-pointer": "^1.2.2",
     "rdf-dataset-ext": "^1.0.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@tpluscode/eslint-config": "^0.3.0",
     "@tpluscode/rdf-string": "^0.2.26",
     "@types/chai": "^4.3.0",
+    "@types/chai-subset": "^1",
     "@types/mocha": "^9.1.0",
     "@types/rdf-dataset-ext": "^1.0.2",
     "@types/rdfjs__formats-common": "^2.0.2",
@@ -62,6 +63,7 @@
     "argparse": "^2.0.1",
     "c8": "^7.11.0",
     "chai": "^4.3.6",
+    "chai-subset": "^1.6.0",
     "docker-compose": "^0.23.17",
     "eslint": "^8.13.0",
     "eslint-config-standard": "^16.0.3",
@@ -83,6 +85,7 @@
   },
   "mocha": {
     "loader": "ts-node/esm",
+    "require": "test/mocha-setup.cjs",
     "extension": [
       "ts"
     ]

--- a/resources.ts
+++ b/resources.ts
@@ -6,7 +6,7 @@ import { toSparql } from 'clownface-shacl-path'
 import { StreamClient } from 'sparql-http-client'
 import fromStream from 'rdf-dataset-ext/fromStream.js'
 import rdf from '@rdfjs/data-model'
-import { getHierarchyPatterns } from './lib/patterns.js'
+import { bottomUp } from './lib/patterns.js'
 import { requiredPath } from './lib/firstLevel.js'
 
 /**
@@ -15,7 +15,7 @@ import { requiredPath } from './lib/firstLevel.js'
  * @param {GraphPointer} hierarchyLevel it must be a pointer to the full hierarchy dataset
  */
 export function example(hierarchyLevel: GraphPointer): Construct | null {
-  const patterns = getHierarchyPatterns(hierarchyLevel, {
+  const patterns = bottomUp(hierarchyLevel, {
     firstLevel: requiredPath,
   })
   if (!patterns) {
@@ -55,7 +55,7 @@ export function children(
   parent: Term,
   { limit = 1, offset = 0, orderBy = [] }: ChildrenOptions = {},
 ): Children | null {
-  const patterns = getHierarchyPatterns(level, {
+  const patterns = bottomUp(level, {
     firstLevel: requiredPath,
   })
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -12,45 +12,98 @@ describe('@zazuko/cube-hierarchy-query', () => {
 
   before(insertGeoData)
 
-  describe('getHierarchy', async () => {
-    // given
-    const hierarchy = await parse`
-        <>
-          ${meta.hierarchyRoot} <Europe>, <North-America>, <South-America> ;
-          ${meta.nextInHierarchy} <countryLevel> ;
-        .
-        
-        <countryLevel>
-          ${sh.path} [
-            ${sh.inversePath} ${schema.containedInPlace} ;
-          ] ;
-          ${meta.nextInHierarchy} <cantonLevel> ;
-        .
-        
-        <cantonLevel> 
-          ${sh.path} [
-            ${sh.inversePath} ${schema.containedInPlace} ;
-          ] ;
-          ${meta.nextInHierarchy} <municipalityLevel> ;
-        .
-        
-        <municipalityLevel> 
-          ${sh.path} [
-            ${sh.inversePath} ${schema.containedInPlace} ;
-          ] ;
-          ${meta.nextInHierarchy} <districtLevel> ;
-        .
-        
-        <districtLevel> ${sh.path} ${schema.containsPlace} .
-      `
+  describe('getHierarchy', () => {
+    const countriesHierarchy = parse`
+      <>
+        ${meta.hierarchyRoot} <Europe>, <North-America>, <South-America> ;
+        ${meta.nextInHierarchy} <countryLevel> ;
+      .
+      
+      <countryLevel>
+        ${sh.path} [
+          ${sh.inversePath} ${schema.containedInPlace} ;
+        ] ;
+        ${meta.nextInHierarchy} <cantonLevel> ;
+      .
+      
+      <cantonLevel> 
+        ${sh.path} [
+          ${sh.inversePath} ${schema.containedInPlace} ;
+        ] ;
+        ${meta.nextInHierarchy} <municipalityLevel> ;
+      .
+      
+      <municipalityLevel> 
+        ${sh.path} [
+          ${sh.inversePath} ${schema.containedInPlace} ;
+        ] ;
+        ${meta.nextInHierarchy} <districtLevel> ;
+      .
+      
+      <districtLevel> ${sh.path} ${schema.containsPlace} .
+    `
 
-    // when
-    const hierarchyTree = await getHierarchy(hierarchy.namedNode(ex(''))).execute(streamClient, $rdf)
-    const json = hierarchyTree.map(toPlain)
+    it('loads all levels', async () => {
+      // given
+      const hierarchy = await countriesHierarchy
 
-    // then
-    expect(json).to.deep.eq([
-      {
+      // when
+      const hierarchyTree = await getHierarchy(hierarchy.namedNode(ex(''))).execute(streamClient, $rdf)
+      const plainTree = hierarchyTree.map(toPlain)
+
+      // then
+      expect(plainTree).to.containSubset([
+        {
+          resource: ex('Europe'),
+          nextInHierarchy: [
+            {
+              resource: ex('CH'),
+              nextInHierarchy: [
+                {
+                  resource: ex('ZH'),
+                  nextInHierarchy: [
+                    {
+                      resource: ex('Affoltern'),
+                      nextInHierarchy: [
+                        { resource: ex('Bonstetten') },
+                        { resource: ex('Rifferswil') },
+                        { resource: ex('Stallikon') },
+                        { resource: ex('Knonau') },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  resource: ex('BE'),
+                  nextInHierarchy: [
+                    {
+                      resource: ex('Biel-Bienne'),
+                      nextInHierarchy: [
+                        { resource: ex('Aegerten') },
+                        { resource: ex('Ligerz') },
+                        { resource: ex('Nidau') },
+                        { resource: ex('Port') },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ])
+    })
+
+    it('loads shallower paths', async () => {
+      // given
+      const hierarchy = await countriesHierarchy
+
+      // when
+      const hierarchyTree = await getHierarchy(hierarchy.namedNode(ex(''))).execute(streamClient, $rdf)
+      const plainTree = hierarchyTree.map(toPlain)
+
+      // then
+      expect(plainTree).to.containSubset([{
         resource: ex('North-America'),
         nextInHierarchy: [
           { resource: ex('US') },
@@ -63,50 +116,37 @@ describe('@zazuko/cube-hierarchy-query', () => {
           { resource: ex('AR') },
           { resource: ex('VE') },
         ],
-      },
-      {
-        resource: ex('Europe-America'),
+      }])
+    })
+
+    it('applies type filter', async () => {
+      // given
+      const hierarchy = await countriesHierarchy
+      hierarchy.namedNode(ex('countryLevel'))
+        .addOut(sh.targetClass, ex.Country)
+
+      // when
+      const hierarchyTree = await getHierarchy(hierarchy.namedNode(ex(''))).execute(streamClient, $rdf)
+      const plainTree = hierarchyTree.map(toPlain)
+
+      // then
+      expect(plainTree).not.to.containSubset([{
+        resource: ex('Europe'),
         nextInHierarchy: [
-          {
-            resource: ex('CH'),
-            nextInHierarchy: [
-              {
-                resource: ex('ZH'),
-                nextInHierarchy: [
-                  {
-                    resource: ex('Affoltern'),
-                    nextInHierarchy: [
-                      { resource: ex('Bonstetten') },
-                      { resource: ex('Rifferswil') },
-                      { resource: ex('Stallikon') },
-                      { resource: ex('Knonau') },
-                    ],
-                  },
-                ],
-              },
-              {
-                resource: ex('BE'),
-                nextInHierarchy: [
-                  {
-                    resource: ex('Biel-Bienne'),
-                    nextInHierarchy: [
-                      { resource: ex('Aegerten') },
-                      { resource: ex('Ligerz') },
-                      { resource: ex('Nidau') },
-                      { resource: ex('Port') },
-                    ],
-                  },
-                ],
-              },
-            ],
-          },
+          { resource: $rdf.namedNode('https://sws.geonames.org/798544') },
         ],
-      },
-    ])
+      }])
+    })
   })
 })
 
 function toPlain(node: HierarchyNode): Record<string, unknown> {
+  if (!node.nextInHierarchy.length) {
+    return {
+      resource: node.resource.term,
+    }
+  }
+
   return {
     resource: node.resource.term,
     nextInHierarchy: node.nextInHierarchy.map(toPlain),

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,0 +1,114 @@
+import { meta } from '@zazuko/vocabulary-extras/builders'
+import { schema, sh } from '@tpluscode/rdf-ns-builders'
+import { expect } from 'chai'
+import $rdf from 'rdf-ext'
+import { getHierarchy, HierarchyNode } from '../index.js'
+import { ex, parse, startFuseki } from './support.js'
+import { insertGeoData } from './testData.js'
+import { streamClient } from './client.js'
+
+describe('@zazuko/cube-hierarchy-query', () => {
+  before(startFuseki)
+
+  before(insertGeoData)
+
+  describe('getHierarchy', async () => {
+    // given
+    const hierarchy = await parse`
+        <>
+          ${meta.hierarchyRoot} <Europe>, <North-America>, <South-America> ;
+          ${meta.nextInHierarchy} <countryLevel> ;
+        .
+        
+        <countryLevel>
+          ${sh.path} [
+            ${sh.inversePath} ${schema.containedInPlace} ;
+          ] ;
+          ${meta.nextInHierarchy} <cantonLevel> ;
+        .
+        
+        <cantonLevel> 
+          ${sh.path} [
+            ${sh.inversePath} ${schema.containedInPlace} ;
+          ] ;
+          ${meta.nextInHierarchy} <municipalityLevel> ;
+        .
+        
+        <municipalityLevel> 
+          ${sh.path} [
+            ${sh.inversePath} ${schema.containedInPlace} ;
+          ] ;
+          ${meta.nextInHierarchy} <districtLevel> ;
+        .
+        
+        <districtLevel> ${sh.path} ${schema.containsPlace} .
+      `
+
+    // when
+    const hierarchyTree = await getHierarchy(hierarchy.namedNode(ex(''))).execute(streamClient, $rdf)
+    const json = hierarchyTree.map(toPlain)
+
+    // then
+    expect(json).to.deep.eq([
+      {
+        resource: ex('North-America'),
+        nextInHierarchy: [
+          { resource: ex('US') },
+        ],
+      },
+      {
+        resource: ex('South-America'),
+        nextInHierarchy: [
+          { resource: ex('BR') },
+          { resource: ex('AR') },
+          { resource: ex('VE') },
+        ],
+      },
+      {
+        resource: ex('Europe-America'),
+        nextInHierarchy: [
+          {
+            resource: ex('CH'),
+            nextInHierarchy: [
+              {
+                resource: ex('ZH'),
+                nextInHierarchy: [
+                  {
+                    resource: ex('Affoltern'),
+                    nextInHierarchy: [
+                      { resource: ex('Bonstetten') },
+                      { resource: ex('Rifferswil') },
+                      { resource: ex('Stallikon') },
+                      { resource: ex('Knonau') },
+                    ],
+                  },
+                ],
+              },
+              {
+                resource: ex('BE'),
+                nextInHierarchy: [
+                  {
+                    resource: ex('Biel-Bienne'),
+                    nextInHierarchy: [
+                      { resource: ex('Aegerten') },
+                      { resource: ex('Ligerz') },
+                      { resource: ex('Nidau') },
+                      { resource: ex('Port') },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ])
+  })
+})
+
+function toPlain(node: HierarchyNode): Record<string, unknown> {
+  return {
+    resource: node.resource.term,
+    nextInHierarchy: node.nextInHierarchy.map(toPlain),
+  }
+}

--- a/test/introspect.test.ts
+++ b/test/introspect.test.ts
@@ -6,35 +6,13 @@ import TermSet from '@rdfjs/term-set'
 import { meta } from '@zazuko/vocabulary-extras/builders'
 import { properties, types } from '../introspect.js'
 import { client } from './client.js'
-import { ex, parse, startFuseki, testData } from './support.js'
+import { ex, parse, startFuseki } from './support.js'
+import { insertGeoData } from './testData.js'
 
 describe('@zazuko/cube-hierarchy-query/introspect', () => {
   before(startFuseki)
 
-  before(async function () {
-    await testData`
-      <US> a ${ex.Country} ; ${schema.containedInPlace} <North-America> .
-      <BR> a ${ex.Country} ; ${schema.containedInPlace} <South-America> .
-
-      <CH> a ${ex.Country} ; ${schema.containedInPlace} <Europe> .
-
-      <https://sws.geonames.org/2658434>
-        a ${gn.A} ; ${gn.parentFeature} <Europe> .
-
-
-      <https://sws.geonames.org/798544>
-        a ${gn.A} ; ${schema.containedInPlace} <Europe> .
-
-      <ZH> a ${ex.Canton} ; ${schema.containedInPlace} <CH> .
-
-      <Affoltern> a ${ex.District} ;
-        ${schema.containedInPlace} <ZH> ;
-        ${schema.containsPlace} <Bonstetten> ;
-      .
-
-      <Bonstetten> a ${ex.Municipality} .
-    `
-  })
+  before(insertGeoData)
 
   describe('properties', () => {
     it('returns properties for first level', async () => {

--- a/test/mocha-setup.cjs
+++ b/test/mocha-setup.cjs
@@ -1,0 +1,4 @@
+const deepEqualInAnyOrder = require('chai-subset');
+const chai = require('chai');
+
+chai.use(deepEqualInAnyOrder);

--- a/test/resources.test.ts
+++ b/test/resources.test.ts
@@ -5,40 +5,13 @@ import clownface from 'clownface'
 import { meta } from '@zazuko/vocabulary-extras/builders'
 import { children, example } from '../resources.js'
 import { client, streamClient } from './client.js'
-import { ex, parse, startFuseki, testData } from './support.js'
+import { ex, parse, startFuseki } from './support.js'
+import { insertGeoData } from './testData.js'
 
 describe('@zazuko/cube-hierarchy-query/resources', () => {
   before(startFuseki)
 
-  before(async function () {
-    await testData`
-      <US> a ${ex.Country} ; ${schema.containedInPlace} <North-America> .
-      <BR> a ${ex.Country} ; ${schema.containedInPlace} <South-America> .
-      <AR> a ${ex.Country} ; ${schema.containedInPlace} <South-America> .
-      <VE> a ${ex.Country} ; ${schema.containedInPlace} <South-America> .
-
-      <CH> a ${ex.Country} ; ${schema.containedInPlace} <Europe> .
-
-      <https://sws.geonames.org/2658434>
-        a ${gn.A} ; ${gn.parentFeature} <Europe> .
-
-
-      <https://sws.geonames.org/798544>
-        a ${gn.A} ; ${schema.containedInPlace} <Europe> .
-
-      <ZH> a ${ex.Canton} ; ${schema.containedInPlace} <CH> .
-
-      <Affoltern> a ${ex.District} ;
-        ${schema.containedInPlace} <ZH> ;
-        ${schema.containsPlace} <Bonstetten>, <Rifferswil>, <Stallikon>, <Knonau> ;
-      .
-
-      <Bonstetten> a ${ex.Municipality} ; ${schema.name} "Bonstetten" .
-      <Rifferswil> a ${ex.Municipality} ; ${schema.name} "Rifferswil" .
-      <Stallikon> a ${ex.Municipality} ; ${schema.name} "Stallikon" .
-      <Knonau> a ${ex.Municipality} ; ${schema.name} "Knonau" .
-    `
-  })
+  before(insertGeoData)
 
   describe('example', () => {
     it('returns empty query when last property id not defined', async () => {

--- a/test/support.ts
+++ b/test/support.ts
@@ -23,7 +23,7 @@ export async function startFuseki(this: Context) {
   })
 }
 
-export async function testData(strings: TemplateStringsArray, ...values: TurtleValue[]) {
+export async function insertTestData(strings: TemplateStringsArray, ...values: TurtleValue[]) {
   const query = sparql`
       DROP SILENT GRAPH ${testDataGraph} ;
 

--- a/test/testData.ts
+++ b/test/testData.ts
@@ -12,7 +12,6 @@ export const insertGeoData = () => insertTestData`
   <https://sws.geonames.org/2658434>
     a ${gn.A} ; ${gn.parentFeature} <Europe> .
 
-
   <https://sws.geonames.org/798544>
     a ${gn.A} ; ${schema.containedInPlace} <Europe> .
 

--- a/test/testData.ts
+++ b/test/testData.ts
@@ -1,0 +1,37 @@
+import { gn, schema } from '@tpluscode/rdf-ns-builders'
+import { ex, insertTestData } from './support.js'
+
+export const insertGeoData = () => insertTestData`
+  <US> a ${ex.Country} ; ${schema.containedInPlace} <North-America> .
+  <BR> a ${ex.Country} ; ${schema.containedInPlace} <South-America> .
+  <AR> a ${ex.Country} ; ${schema.containedInPlace} <South-America> .
+  <VE> a ${ex.Country} ; ${schema.containedInPlace} <South-America> .
+
+  <CH> a ${ex.Country} ; ${schema.containedInPlace} <Europe> .
+
+  <https://sws.geonames.org/2658434>
+    a ${gn.A} ; ${gn.parentFeature} <Europe> .
+
+
+  <https://sws.geonames.org/798544>
+    a ${gn.A} ; ${schema.containedInPlace} <Europe> .
+
+  <ZH> a ${ex.Canton} ; ${schema.containedInPlace} <CH> .
+
+  <Affoltern> a ${ex.District} ;
+    ${schema.containedInPlace} <ZH> ;
+    ${schema.containsPlace} <Bonstetten>, <Rifferswil>, <Stallikon>, <Knonau> ;
+  .
+
+  <Bonstetten> a ${ex.Municipality} ; ${schema.name} "Bonstetten" .
+  <Rifferswil> a ${ex.Municipality} ; ${schema.name} "Rifferswil" .
+  <Stallikon> a ${ex.Municipality} ; ${schema.name} "Stallikon" .
+  <Knonau> a ${ex.Municipality} ; ${schema.name} "Knonau" .
+  
+  <BE> a ${ex.Canton} ; ${schema.containedInPlace} <CH> .
+  
+  <Biel-Bienne> a ${ex.District} ;
+    ${schema.containedInPlace} <BE> ;
+    ${schema.containsPlace} <Aegerten>, <Ligerz>, <Nidau>, <Port> ;
+  .
+`

--- a/yarn.lock
+++ b/yarn.lock
@@ -661,10 +661,17 @@
   resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.2.tgz#423c77877d0569db20e1fc80885ac4118314010e"
   integrity sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==
 
-"@types/chai@^4.3.0":
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.3.0.tgz#23509ebc1fa32f1b4d50d6a66c4032d5b8eaabdc"
-  integrity sha512-/ceqdqeRraGolFTcfoXNiqjyQhZzbINDngeoAq9GoHa8PPK1yNzTaxWjA6BFWp5Ua9JpXEMSS4s5i9tS0hOJtw==
+"@types/chai-subset@^1":
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/@types/chai-subset/-/chai-subset-1.3.3.tgz#97893814e92abd2c534de422cb377e0e0bdaac94"
+  integrity sha512-frBecisrNGz+F4T6bcc+NLeolfiojh5FxW2klu669+8BARtyQv2C/GkNW6FUodVe4BroGMP/wER/YDGc7rEllw==
+  dependencies:
+    "@types/chai" "*"
+
+"@types/chai@*", "@types/chai@^4.3.0":
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.3.1.tgz#e2c6e73e0bdeb2521d00756d099218e9f5d90a04"
+  integrity sha512-/zPMqDkzSZ8t3VtxOa4KPq7uzzW978M9Tvh+j7GHKuo6k6GTLxPJ4J5gE5cjfJ26pnXst0N5Hax8Sr0T2Mi9zQ==
 
 "@types/clownface@^1.5.0":
   version "1.5.0"
@@ -1157,6 +1164,11 @@ canonicalize@^1.0.1:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/canonicalize/-/canonicalize-1.0.8.tgz#24d1f1a00ed202faafd9bf8e63352cd4450c6df1"
   integrity sha512-0CNTVCLZggSh7bc5VkX5WWPWO+cyZbNd07IHIsSXLia/eAq+r836hgk+8BKoEh7949Mda87VUOitx5OddVj64A==
+
+chai-subset@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/chai-subset/-/chai-subset-1.6.0.tgz#a5d0ca14e329a79596ed70058b6646bd6988cfe9"
+  integrity sha512-K3d+KmqdS5XKW5DWPd5sgNffL3uxdDe+6GdnJh3AYPhwnBGRY5urfvfcbRtWIvvpz+KxkL9FeBB6MZewLUNwug==
 
 chai@^4.3.6:
   version "4.3.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2336,6 +2336,13 @@ is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3, is-glob@~4.0.1:
   dependencies:
     is-extglob "^2.1.1"
 
+is-graph-pointer@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/is-graph-pointer/-/is-graph-pointer-1.2.2.tgz#1517f8f99f5347b2a02b92943df9d442771fdf6a"
+  integrity sha512-lF59hoMoZxh9T1bRrjQEiifS+FNJC0cw2rlKCOlDMCfrpwgDbHmhkKE1L3NfVQBF8eNgm6U40rdy0M9SzwCS2A==
+  dependencies:
+    "@types/clownface" "^1.5.0"
+
 is-negative-zero@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.2.tgz#7bf6f03a28003b8b3965de3ac26f664d765f3150"


### PR DESCRIPTION
This PR adds a main module with a function to get entire hierarchy in on query.

Here's an example of such a query: https://s.zazuko.com/fJBAbD

The nested `OPTIONAL` may not be most efficient but a necessity if we accept that not all branches in a hierarchical structure will reach the bottom. Might add an option to disable that and only retrieve branches spanning full hierarchy?

CC @ptbrowne 