### PR TITLE
fix: Hierarchy query returns roots that have no children

### DIFF
--- a/.changeset/shiny-stingrays-reflect.md
+++ b/.changeset/shiny-stingrays-reflect.md
@@ -1,0 +1,5 @@
+---
+"@zazuko/cube-hierarchy-query": patch
+---
+
+Roots without children were not returned by the `getHierarchy` function

--- a/index.ts
+++ b/index.ts
@@ -38,11 +38,9 @@ export interface Hierarchy {
 }
 
 export function getHierarchy(hierarchy: GraphPointer): Hierarchy {
-  const query = DESCRIBE`*`
-    .WHERE`
-      ${topDown(hierarchy)}
-    `
-
+  const { described, where } = topDown(hierarchy)
+  const query = DESCRIBE`${described}`
+    .WHERE`${where}`
   return {
     query,
     async execute(client, $rdf) {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -15,7 +15,7 @@ describe('@zazuko/cube-hierarchy-query', () => {
   describe('getHierarchy', () => {
     const countriesHierarchy = parse`
       <>
-        ${meta.hierarchyRoot} <Europe>, <North-America>, <South-America> ;
+        ${meta.hierarchyRoot} <Europe>, <North-America>, <South-America>, <Asia> ;
         ${meta.nextInHierarchy} <countryLevel> ;
       .
       
@@ -90,6 +90,9 @@ describe('@zazuko/cube-hierarchy-query', () => {
               ],
             },
           ],
+        },
+        {
+          resource: ex('Asia'),
         },
       ])
     })


### PR DESCRIPTION
Previously, roots without children were skipped from being returned
by the describe query, resulting in them not having any label
in visualize.admin UI. ﻿

Fixes https://github.com/zazuko/cube-hierarchy-query/pull/11
