### PR TITLE
Subqueries

### DIFF
--- a/.changeset/short-lions-cough.md
+++ b/.changeset/short-lions-cough.md
@@ -1,0 +1,5 @@
+---
+"@zazuko/cube-hierarchy-query": patch
+---
+
+Improve performance of queries by using subselects (updates `@hydrofoil/shape-to-query` to `v0.10`) (closes #34)

--- a/.changeset/short-lions-cough.md
+++ b/.changeset/short-lions-cough.md
@@ -2,4 +2,4 @@
 "@zazuko/cube-hierarchy-query": patch
 ---
 
-Improve performance of queries by using subselects (updates `@hydrofoil/shape-to-query` to `v0.10`) (closes #34)
+Improve performance of queries by using subselects (updates `@hydrofoil/shape-to-query` to `v0.10`) (closes #34, closes #21)

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 coverage/
 *.js
+/.env

--- a/examples/hierarchy.ts
+++ b/examples/hierarchy.ts
@@ -13,6 +13,7 @@ const main = async () => {
   parser.add_argument('--cube', { required: true })
   parser.add_argument('--dimensionIri', { required: false })
   parser.add_argument('--endpoint', { required: false, default: 'https://int.lindas.admin.ch/query' })
+  parser.add_argument('--print-query', { action: 'store_true' })
 
   const args = parser.parse_args()
   const endpoint = {
@@ -41,13 +42,20 @@ const main = async () => {
     throw new Error(`Hierarchy not found ${args.dimensionIri}`)
   }
 
-  performance.mark('begin getHierarchy')
-  const results = await getHierarchy(hierarchy, {
+  const hierarchyQuery = getHierarchy(hierarchy, {
     properties: [
       $rdf.ns.schema.identifier,
       [$rdf.ns.schema.name, { language: 'de' }],
     ],
-  }).execute(client, $rdf)
+  })
+
+  if (args.print_query) {
+    console.log(hierarchyQuery.query.build())
+    process.exit(0)
+  }
+
+  performance.mark('begin getHierarchy')
+  const results = await hierarchyQuery.execute(client, $rdf)
   performance.mark('end getHierarchy')
   performance.measure('getHierarchy', 'begin getHierarchy', 'end getHierarchy')
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,22 @@
 {
   "name": "@zazuko/cube-hierarchy-query",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zazuko/cube-hierarchy-query",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "license": "MIT",
       "dependencies": {
-        "@hydrofoil/shape-to-query": "^0.9.4",
+        "@hydrofoil/shape-to-query": "^0.10.0",
         "@tpluscode/sparql-builder": "^1.1.0",
         "@types/sparql-http-client": "^2.2.8",
         "@zazuko/env": "^2.0.3",
         "@zazuko/vocabulary-extras-builders": "^1.1.3",
         "clownface-shacl-path": "^2.1.0",
-        "is-graph-pointer": "^2.1.0"
+        "is-graph-pointer": "^2.1.0",
+        "rdf-dataset-ext": "^1.1.0"
       },
       "devDependencies": {
         "@changesets/cli": "^2.22.0",
@@ -1128,16 +1129,16 @@
       "peer": true
     },
     "node_modules/@hydrofoil/shape-to-query": {
-      "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/@hydrofoil/shape-to-query/-/shape-to-query-0.9.4.tgz",
-      "integrity": "sha512-ViSh75GWsabtqJc6DkC1/9adJASibqmc4VSwkurr0N8gu/0/OOr0p8fvR/HmjZX8KJDcYcVq7tgdxj7m5kJpAg==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@hydrofoil/shape-to-query/-/shape-to-query-0.10.0.tgz",
+      "integrity": "sha512-po4N7oSV4/EF/nZk6ufI40SCe9lVV36IIYXRi9xotUEx6IfAe4761ce/eP8AdXdHHBs67HrnR+KOWCGdmNMqNw==",
       "dependencies": {
         "@tpluscode/rdf-ns-builders": ">=3.0.2",
         "@tpluscode/rdf-string": "^1.0.3",
         "@tpluscode/sparql-builder": "^1.1.0",
         "@vocabulary/dash": "^1.0.1",
         "@vocabulary/dash-sparql": "^1.0.1",
-        "@vocabulary/sh": "^1.0.1",
+        "@vocabulary/sh": "^1.1.3",
         "@zazuko/env": "^2.0.3",
         "@zazuko/prefixes": ">=2",
         "clownface-shacl-path": "^2.0.1",
@@ -2537,9 +2538,9 @@
       "dev": true
     },
     "node_modules/@vocabulary/sh": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@vocabulary/sh/-/sh-1.0.1.tgz",
-      "integrity": "sha512-hw/Y0EhVKT9sq6AvyE3Pidj/X1LopPAdiHGqhNTgghWFjRaAQd9jud/K4RGMkq/x+W1iwhGcnj8rrxKKghe9Qw=="
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@vocabulary/sh/-/sh-1.1.4.tgz",
+      "integrity": "sha512-i8tNVIZHtusciU0oTAXVlD/vughLRIqHLt0c59099UiSiOHfRxE8iuiTHCWV9+a8RS/ftfZEyjDxHnmvjJgxBA=="
     },
     "node_modules/@zazuko/env": {
       "version": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "homepage": "https://github.com/zazuko/cube-hierarchy-query#readme",
   "dependencies": {
-    "@hydrofoil/shape-to-query": "^0.9.4",
+    "@hydrofoil/shape-to-query": "^0.10.0",
     "@tpluscode/sparql-builder": "^1.1.0",
     "@types/sparql-http-client": "^2.2.8",
     "@zazuko/env": "^2.0.3",

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -5,19 +5,26 @@ exports[`@zazuko/cube-hierarchy-query getHierarchy loads all levels 1`] = `
 
 CONSTRUCT { 
     ?resource2 schema:containedInPlace ?resource1 .
+?resource1 ?resource24 ?resource25 .
 ?resource3 schema:containedInPlace ?resource2 .
+?resource2 ?resource18 ?resource19 .
 ?resource4 schema:containedInPlace ?resource3 .
+?resource3 ?resource13 ?resource14 .
 ?resource4 schema:containsPlace ?resource5 .
+?resource4 ?resource9 ?resource10 .
 ?resource5 ?resource6 ?resource7 .
-?resource4 ?resource8 ?resource9 .
-?resource3 ?resource10 ?resource11 .
-?resource2 ?resource12 ?resource13 .
-?resource1 ?resource14 ?resource15 .
    }
 
 WHERE {
 
-    
+    { 
+    { SELECT ?resource2
+?resource1
+?resource24
+?resource25
+
+WHERE {
+
 
 VALUES ( ?resource1 )
 {
@@ -27,48 +34,193 @@ VALUES ( ?resource1 )
 ( <http://example.com/Asia> )
 }
 { 
-    { 
     
+
 ?resource2 schema:containedInPlace ?resource1 .
  
   } UNION {
       
+        ?resource1 ?resource24 ?resource25 .
+        
+        
+      
+    }
+
+
+
+
+}
+
+
+
+ } 
+  } UNION {
+      { SELECT ?resource3
+?resource2
+?resource18
+?resource19
+
+WHERE {
+
+            
+VALUES ( ?resource1 )
+{
+( <http://example.com/Europe> )
+( <http://example.com/North-America> )
+( <http://example.com/South-America> )
+( <http://example.com/Asia> )
+}
             
 ?resource2 schema:containedInPlace ?resource1 .
 
             
 
 { 
-    { 
     
+
 ?resource3 schema:containedInPlace ?resource2 .
  
   } UNION {
       
+        ?resource2 ?resource18 ?resource19 .
+        
+        
+      
+    }
+
+          
+
+
+}
+
+
+
+ }
+    } UNION {
+      { SELECT ?resource4
+?resource3
+?resource13
+?resource14
+
+WHERE {
+
+            
+VALUES ( ?resource1 )
+{
+( <http://example.com/Europe> )
+( <http://example.com/North-America> )
+( <http://example.com/South-America> )
+( <http://example.com/Asia> )
+}
+
+?resource2 schema:containedInPlace ?resource1 .
+
+
             
 ?resource3 schema:containedInPlace ?resource2 .
 
             
 
 { 
-    { 
     
+
 ?resource4 schema:containedInPlace ?resource3 .
  
   } UNION {
       
+        ?resource3 ?resource13 ?resource14 .
+        
+        
+      
+    }
+
+          
+
+
+}
+
+
+
+ }
+    } UNION {
+      { SELECT ?resource4
+?resource5
+?resource9
+?resource10
+
+WHERE {
+
+            
+VALUES ( ?resource1 )
+{
+( <http://example.com/Europe> )
+( <http://example.com/North-America> )
+( <http://example.com/South-America> )
+( <http://example.com/Asia> )
+}
+
+?resource2 schema:containedInPlace ?resource1 .
+
+
+
+?resource3 schema:containedInPlace ?resource2 .
+
+
             
 ?resource4 schema:containedInPlace ?resource3 .
 
             
 
 { 
-    { 
     
+
 ?resource4 schema:containsPlace ?resource5 .
  
   } UNION {
       
+        ?resource4 ?resource9 ?resource10 .
+        
+
+FILTER((!((?resource9 = schema:containsPlace))))
+        
+      
+    }
+
+          
+
+
+}
+
+
+
+ }
+    } UNION {
+      { SELECT ?resource5
+?resource6
+?resource7
+
+WHERE {
+
+            
+VALUES ( ?resource1 )
+{
+( <http://example.com/Europe> )
+( <http://example.com/North-America> )
+( <http://example.com/South-America> )
+( <http://example.com/Asia> )
+}
+
+?resource2 schema:containedInPlace ?resource1 .
+
+
+
+?resource3 schema:containedInPlace ?resource2 .
+
+
+
+?resource4 schema:containedInPlace ?resource3 .
+
+
             
 ?resource4 schema:containsPlace ?resource5 .
 
@@ -81,48 +233,14 @@ VALUES ( ?resource1 )
       
 
           
-    } 
-  } UNION {
-      
-        ?resource4 ?resource8 ?resource9 .
-        
 
-FILTER((!((?resource8 = schema:containsPlace))))
-        
-      
+
+}
+
+
+
+ }
     }
-
-          
-    } 
-  } UNION {
-      
-        ?resource3 ?resource10 ?resource11 .
-        
-        
-      
-    }
-
-          
-    } 
-  } UNION {
-      
-        ?resource2 ?resource12 ?resource13 .
-        
-        
-      
-    }
-
-          
-    } 
-  } UNION {
-      
-        ?resource1 ?resource14 ?resource15 .
-        
-        
-      
-    }
-
-
   
 }
 "


### PR DESCRIPTION
With a change in how the queries are generated in general, using `SELECT` subqueries and less `UNION`, all hierarchies I tried appear to run at sub-second times. The performance counter in the example may show higher numbers but that is in the case of parsing large term sets as far as I can tell.

cc @Rdataflow