### PR TITLE
compatibility fix for fuseki et al

### DIFF
--- a/lib/hierarchyShape.ts
+++ b/lib/hierarchyShape.ts
@@ -88,10 +88,6 @@ function addPropertyConstraints(shape: GraphPointer, { properties = [] }: Hierar
   }
 
   properties.forEach(addProperty.bind(null, shape))
-
-  if (!properties.find(([prop]) => prop.equals(rdf.ns.rdf.type))) {
-    addProperty(shape, [rdf.ns.rdf.type, {}])
-  }
 }
 
 function addProperty(shape: GraphPointer, [property, constraints]: PropertyWithConstraints) {


### PR DESCRIPTION
while some SPARQL engines handle the `UNION` nested occurrence of the redundant triple `?ressourceY rdf:type ?resourceY .` others slow down (QLever) or timeout (fuseki)

by removing this redundant triple for common cases no difference in result set is observed

works perfectly 
- https://s.zazuko.com/MgetGu (see commented lines)

doesn't work for fuseki et al
- https://s.zazuko.com/FNy5xt

cc @tpluscode 